### PR TITLE
Rename streaming event consumer

### DIFF
--- a/src/rtaoai2/openai/consumer.py
+++ b/src/rtaoai2/openai/consumer.py
@@ -92,14 +92,14 @@ class OpenAIWaitInputTranscriptEventConsumer:
             self.process_event_state = ResponseState.WAITING_RESPONSE_DONE
 
 
-class OpenAIStreamingEventConsummer:
-    def __init__(self, event_consummer, response_producer):
-        self.event_consummer = event_consummer
+class OpenAIStreamingEventConsumer:
+    def __init__(self, event_consumer, response_producer):
+        self.event_consumer = event_consumer
         self.response_producer = response_producer
 
     async def on_event(self, event):
         try:
-            event = self.event_consummer.process_event(event)
+            event = self.event_consumer.process_event(event)
         except UnknownEventError:
             event = None
         if isinstance(event, ResponseAudioDeltaEvent):

--- a/src/rtaoai2/server.py
+++ b/src/rtaoai2/server.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 import websockets
 
-from rtaoai2.openai.consumer import OpenAIEventConsumer, OpenAIStreamingEventConsummer
+from rtaoai2.openai.consumer import OpenAIEventConsumer, OpenAIStreamingEventConsumer
 from rtaoai2.openai.producer import OpenAIEventProducer
 from rtaoai2.ui.consumer import EventConsumer
 from rtaoai2.ui.producer import EventProducer
@@ -105,7 +105,7 @@ async def websocket_endpoint(websocket: WebSocket):
     ui_event_consumer = EventConsumer(openai_event_producer)
 
     ui_event_producer = EventProducer(websocket)
-    openai_event_consumer = OpenAIStreamingEventConsummer(
+    openai_event_consumer = OpenAIStreamingEventConsumer(
         OpenAIEventConsumer(), ui_event_producer
     )
 

--- a/tests/rtaoai/openai/test_consumer.py
+++ b/tests/rtaoai/openai/test_consumer.py
@@ -3,7 +3,7 @@ from rtaoai2.openai.consumer import (
     OpenAIEventConsumer,
     UnknownEventError,
     OpenAIWaitInputTranscriptEventConsumer,
-    OpenAIStreamingEventConsummer,
+    OpenAIStreamingEventConsumer,
 )
 
 import pytest
@@ -215,8 +215,8 @@ async def test_response_producer_ui(
         expected_events.append(("write_response_audio", ""))
 
     response_producer_spy = ResponseProducerConsoleSpy()
-    events_consumer = OpenAIStreamingEventConsummer(
-        event_consummer=OpenAIEventConsumer(), response_producer=response_producer_spy
+    events_consumer = OpenAIStreamingEventConsumer(
+        event_consumer=OpenAIEventConsumer(), response_producer=response_producer_spy
     )
     for e in events_json(".")[48:]:
         await events_consumer.on_event(e)


### PR DESCRIPTION
## Summary
- rename OpenAIStreamingEventConsummer to OpenAIStreamingEventConsumer
- rename event_consummer parameter to event_consumer
- update imports and tests for new names

## Testing
- `PYENV_VERSION=3.12.10 PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `PYENV_VERSION=3.12.10 pip install pydantic` *(fails: Could not find a version that satisfies the requirement pydantic)*
