### PR TITLE
chore: configure uv dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,12 @@ requires-python = ">= 3.8"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.rye]
-managed = true
-dev-dependencies = [
-    "pytest>=8.3.3",
-    "ruff>=0.7.0",
-    "pytest-asyncio>=0.24.0",
-    "pyright>=1.1.385",
+[dependency-groups.dev]
+dependencies = [
+    "pytest",
+    "ruff",
+    "pytest-asyncio",
+    "pyright",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
## Summary
- remove Rye configuration
- define dev dependency group for uv

## Testing
- `pytest` *(fails: pyenv: version `3.12.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bd9964608328bd3c83884b5601e3