### PR TITLE
Fix emitter header in events CSV

### DIFF
--- a/opanai_events.csv
+++ b/opanai_events.csv
@@ -1,4 +1,4 @@
-time;emiter;event
+time;emitter;event
 00:03.44;client;session.update
 00:03.44;client;conversation.item.create
 00:03.44;client;response.create


### PR DESCRIPTION
## Summary
- fix typo in opanai events CSV header (emiter -> emitter)

## Testing
- `python - <<'PY'
import csv
with open('opanai_events.csv', newline='') as f:
    reader = csv.DictReader(f, delimiter=';')
    first = next(reader)
    print(first)
PY`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rtaoai2' / pydantic; cannot install dependencies due to missing hatchling)*