### PR TITLE
Ensure transcript queue flushed before response completion

### DIFF
--- a/src/rtaoai2/openai/consumer.py
+++ b/src/rtaoai2/openai/consumer.py
@@ -73,7 +73,7 @@ class OpenAIWaitInputTranscriptEventConsumer:
         elif isinstance(event, ResponseDoneEvent):
             if self.response_audio_transcript_queue:
                 await self.response_producer.on_response_audio_transcript_delta_event(
-                    event
+                    self.response_audio_transcript_queue
                 )
                 self.response_audio_transcript_queue = ""
             await self.response_producer.on_response_done(event)


### PR DESCRIPTION
## Summary
- Flush any queued audio transcript when `ResponseDoneEvent` arrives by sending the queue, clearing it, and then signalling completion

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*