### PR TITLE
docs: fix Markdown code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This project uses [uv](https://docs.astral.sh/uv/) and requires Python >=3.13 (a
 To run it
 
 Run the backend
-````
+```
 uv sync
 uv run pytest
 OPENAI_API_KEY=$(cat ~/.you_openai_key) uv run fastapi dev src/rtaoai2/server.py
-````
+```
 
 Run the frontend
-````
+```
 cd react-ui
 npm start
-````
+```


### PR DESCRIPTION
## Summary
- fix malformed code blocks in README so backend/frontend instructions render

## Testing
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run mypy src tests` *(fails: Dict entry incompatible type; missing stubs for pydub)*
- `uv run pyright` *(fails: "name" incorrectly overrides property "Event")*
- `uv run pytest`