### PR TITLE
refactor(openai): annotate event names and producer types

### DIFF
--- a/src/rtaoai2/openai/events.py
+++ b/src/rtaoai2/openai/events.py
@@ -1,11 +1,10 @@
 from typing import ClassVar
+
 from pydantic import BaseModel
 
 
 class Event(BaseModel):
-    @property
-    def name(self):
-        raise NotImplementedError
+    name: ClassVar[str]
 
 
 class ResponseAudioDeltaEvent(Event):

--- a/src/rtaoai2/openai/producer.py
+++ b/src/rtaoai2/openai/producer.py
@@ -1,6 +1,6 @@
 import inspect
 import json
-from typing import Callable, Literal, get_origin, get_args
+from typing import Callable, Literal, get_args, get_origin
 
 
 def make_audio(audio: str):
@@ -11,14 +11,14 @@ def make_audio_commit():
     return {"type": "input_audio_buffer.commit"}
 
 
-def tool_to_tool_json(tool: Callable):
+def tool_to_tool_json(tool: Callable) -> dict[str, object]:
     description = tool.__doc__
     name = tool.__name__
-    properties = {}
-    required = []
+    properties: dict[str, dict[str, object]] = {}
+    required: list[str] = []
     for p in inspect.signature(tool).parameters.values():
         if p.annotation is str:
-            property = {"type": "string"}
+            property: dict[str, object] = {"type": "string"}
         elif p.annotation is int:
             property = {"type": "integer"}
         elif p.annotation is float:
@@ -47,11 +47,11 @@ def tool_to_tool_json(tool: Callable):
     }
 
 
-def make_response_create(tools: list[Callable]):
-    session_tools = []
+def make_response_create(tools: list[Callable]) -> dict[str, object]:
+    session_tools: list[dict[str, object]] = []
     for tool in tools:
-        tool = tool_to_tool_json(tool)
-        session_tools.append(tool)
+        tool_json = tool_to_tool_json(tool)
+        session_tools.append(tool_json)
     return {
         "type": "response.create",
         "response": {
@@ -60,11 +60,11 @@ def make_response_create(tools: list[Callable]):
     }
 
 
-def make_session_update(tools: list[Callable]):
-    session_tools = []
+def make_session_update(tools: list[Callable]) -> dict[str, object]:
+    session_tools: list[dict[str, object]] = []
     for tool in tools:
-        tool = tool_to_tool_json(tool)
-        session_tools.append(tool)
+        tool_json = tool_to_tool_json(tool)
+        session_tools.append(tool_json)
     return {
         "type": "session.update",
         "session": {

--- a/src/rtaoai2/server.py
+++ b/src/rtaoai2/server.py
@@ -13,7 +13,7 @@ from rtaoai2.openai.producer import OpenAIEventProducer
 from rtaoai2.ui.consumer import EventConsumer
 from rtaoai2.ui.producer import EventProducer
 
-from pydub import AudioSegment
+from pydub import AudioSegment  # type: ignore[import-untyped]
 
 
 def audio_to_item_create_event(audio_bytes: bytes) -> str:
@@ -94,7 +94,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
     url = "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01"
     headers = {
-        "Authorization": f"Bearer {os.environ["OPENAI_API_KEY"]}",
+        "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}",
         "OpenAI-Beta": "realtime=v1",
     }
     openai_ws = await websockets.connect(url, extra_headers=headers)


### PR DESCRIPTION
## Summary
- replace Event.name property with ClassVar string
- tighten type hints in OpenAI producer helper functions
- silence missing pydub stubs for mypy

## Testing
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run pytest`
- `uv run mypy src tests`
- `uv run pyright`